### PR TITLE
Add support for using https with bulk APIs.

### DIFF
--- a/lib/health_manager/bulk_based_expected_state_provider.rb
+++ b/lib/health_manager/bulk_based_expected_state_provider.rb
@@ -128,7 +128,7 @@ module HealthManager
 
     def bulk_url
       url = "#{host}/bulk"
-      url = "http://"+url unless url.start_with?("http://")
+      url = "http://"+url unless url.start_with?("http://") || url.start_with?("httpis://")
       url
     end
 


### PR DESCRIPTION
Our load balancer that fronts the CF routers requires https. However, the bulk APIs expect http. If an https url is specified, the URL gets prefixed with "http://" and bad things happen.

This small patch solves that problem and allows http or https to be used.
