### PR TITLE
Allow https URL to be used for bulk api calls

### DIFF
--- a/lib/health_manager/bulk_based_expected_state_provider.rb
+++ b/lib/health_manager/bulk_based_expected_state_provider.rb
@@ -128,7 +128,7 @@ module HealthManager
 
     def bulk_url
       url = "#{host}/bulk"
-      url = "http://"+url unless url.start_with?("http://") || url.start_with?("httpis://")
+      url = "http://" + url unless url =~ /^http[s]?:\/\//
       url
     end
 

--- a/lib/health_manager/bulk_based_expected_state_provider.rb
+++ b/lib/health_manager/bulk_based_expected_state_provider.rb
@@ -128,7 +128,7 @@ module HealthManager
 
     def bulk_url
       url = "#{host}/bulk"
-      url = "http://"+url unless url.start_with?("http://")
+      url = "http://"+url unless url.start_with?("http://") || url.start_with?("httpis://")
       url
     end
 

--- a/spec/unit/bulk_expected_state_provider_spec.rb
+++ b/spec/unit/bulk_expected_state_provider_spec.rb
@@ -14,9 +14,32 @@ describe HealthManager::BulkBasedExpectedStateProvider do
       },
     }
   }
+
+  let(:https_bulk_api_host) { "https://" + bulk_api_host }
+  let(:https_config) {
+    {
+        'bulk_api' => {
+            'host' => https_bulk_api_host,
+            'batch_size' => batch_size,
+        },
+    }
+  }
+
   let(:manager) { m = HealthManager::Manager.new(config); m.varz.prepare; m }
   let(:varz) { manager.varz }
   let(:provider) { manager.expected_state_provider }
+
+  describe "Config" do
+    it "should use http URLs" do
+      provider = HealthManager::BulkBasedExpectedStateProvider.new(config)
+      expect(provider.bulk_url).to eq("http://" + bulk_api_host + "/bulk")
+    end
+
+    it "should allow https to be used" do
+      provider = HealthManager::BulkBasedExpectedStateProvider.new(https_config)
+      expect(provider.bulk_url).to eq(https_bulk_api_host + "/bulk")
+    end
+  end
 
   describe "HTTP requests" do
     before do


### PR DESCRIPTION
The bulk api call shouldn't try to force http but rather allow for the use of https.

These are the first rspecs I've ever written so let me know if they look ok or if I should change something.
